### PR TITLE
 Añadir framework Nestjs 

### DIFF
--- a/doc/secciones/05_implementacion.tex
+++ b/doc/secciones/05_implementacion.tex
@@ -92,3 +92,13 @@ Cypress realmente es una herramienta para hacer test E2E y depende del navegador
 Jest tiene una gran comunidad, buena documentación, fácil integración con Typescript, ayuda a mockear los datos necesarios para los tests y trae espiadores integrados.
 Además tiene una cobertura integrada en el código para saber cuánto porcentaje del código está testeado.
 
+\subsubsection*{Framework de desarrollo}
+Durante el desarrollo del proyecto se ha tomado la decisión de usar un framework de desarrollo para facilitar la creación de la aplicación web.
+Utilizar un framework acelera el desarrollo al proporcionar una estructura predefinida, buenas prácticas y herramientas integradas, lo que mejora la calidad del código, la seguridad y la mantenibilidad.
+Además, reduce el tiempo de desarrollo y facilita la escalabilidad, haciendo el proceso más eficiente y organizado.
+Los criterios de búsqueda para el framework serán una configuración sencilla, fácil de usar, que soporte Typescript y Node.js, que se adapte a la situación del proyecto y que sea pragmático.
+He de explicar que el desarrollo del proyecto se centrará en la lógica de negocio y en la parte del backend, por lo que los framework serán orientados a este tipo de desarrollo.
+Las opciones que se han barajado son las siguientes: Express, NestJS, Koa, Hapi. Express se ha descartado por ser una framework muy sencillo y no aporta tanto como los demás.
+Hapi se descarta ya que está enfocado a los plugins, lo que no se ajusta a las necesidades del proyecto. Koa se descarta ya que utiliza una arquitectura de middleware y lo mejor sería una arquitectura modular.
+Finalmente, se ha escogido NestJS por ser el framework que mejor se amolda a nuestro proyecto.
+

--- a/package.json
+++ b/package.json
@@ -9,21 +9,29 @@
     "test": "test"
   },
   "scripts": {
-    "start": "node build/index.js",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build",
     "tsc": "tsc",
-    "lint": "eslint . --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\" --fix",
     "lint:fix": "eslint . --ext .ts --fix",
     "test": "jest"
   },
   "dependencies": {
+    "@nestjs/common": "^10.4.1",
+    "@nestjs/core": "^10.4.1",
+    "@nestjs/platform-express": "^10.4.1",
     "reflect-metadata": "^0.1.14",
-    "rxjs": "^7.8.1",
-    "typescript": "^5.2.2"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
     "@jest/globals": "^29.7.0",
+    "@nestjs/cli": "^10.4.4",
+    "@nestjs/schematics": "^10.1.4",
     "@types/jest": "^29.5.12",
+    "@types/node": "^22.5.1",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.7.4",
     "eslint": "^8.51.0",
@@ -32,6 +40,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.0.3",
     "ts-jest": "^29.2.4",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.4.1",
+    "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.4.1",
     "@nestjs/platform-express": "^10.4.1",
+    "dotenv": "^16.4.5",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1"
   },
@@ -30,6 +32,7 @@
     "@jest/globals": "^29.7.0",
     "@nestjs/cli": "^10.4.4",
     "@nestjs/schematics": "^10.1.4",
+    "@nestjs/testing": "^10.4.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.5.1",
     "@typescript-eslint/eslint-plugin": "^6.13.1",

--- a/src/emergencyTriage.module.ts
+++ b/src/emergencyTriage.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { EmergencyTriageController } from "./emergencyTriage/emergencyTriage.controller";
+import { EmergencyTriageService } from "./emergencyTriage/emergencyTriage.service";
+
+
+@Module({
+    imports: [ConfigModule.forRoot({
+        isGlobal: true,
+        envFilePath: '.env',
+    })],
+    controllers: [EmergencyTriageController],
+    providers: [EmergencyTriageService]
+})
+export class EmergencyTriageModule {}

--- a/src/emergencyTriage/emergencyTriage.controller.test.ts
+++ b/src/emergencyTriage/emergencyTriage.controller.test.ts
@@ -1,0 +1,23 @@
+import { EmergencyTriageController } from "./emergencyTriage.controller";
+import { EmergencyTriageService } from "./emergencyTriage.service";
+
+
+describe('Emergency Triage Controller', () => {
+    let emergencyTriageController: EmergencyTriageController;
+    let emergencyTriageService: EmergencyTriageService;
+
+    beforeEach(() => {
+        emergencyTriageService = new EmergencyTriageService();
+        emergencyTriageController = new EmergencyTriageController(emergencyTriageService);
+    });
+
+    describe('getEmergencyTriageMessage', () => {
+        it('should return a message', () => {
+            const result = 'Emergency Triage';
+            jest.spyOn(emergencyTriageService, 'getEmergencyTriageMessage').mockImplementation(() => result);
+
+            expect(emergencyTriageController.getEmergencyTriageMessage()).toBe(result);
+        });
+    });
+
+});

--- a/src/emergencyTriage/emergencyTriage.controller.ts
+++ b/src/emergencyTriage/emergencyTriage.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from "@nestjs/common";
+import { EmergencyTriageService } from "./emergencyTriage.service";
+
+
+@Controller('emergency-triage')
+export class EmergencyTriageController {
+    constructor(
+        private readonly emergencyTriageService: EmergencyTriageService
+    ) {}
+
+    @Get()
+    getEmergencyTriageMessage(): string {
+        return this.emergencyTriageService.getEmergencyTriageMessage();
+    }
+}

--- a/src/emergencyTriage/emergencyTriage.module.ts
+++ b/src/emergencyTriage/emergencyTriage.module.ts
@@ -1,9 +1,0 @@
-import { Module } from "@nestjs/common";
-
-
-@Module({
-    imports: [],
-    controllers: [],
-    providers: []
-})
-export class EmergencyTriageModule {}

--- a/src/emergencyTriage/emergencyTriage.module.ts
+++ b/src/emergencyTriage/emergencyTriage.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+
+
+@Module({
+    imports: [],
+    controllers: [],
+    providers: []
+})
+export class EmergencyTriageModule {}

--- a/src/emergencyTriage/emergencyTriage.service.ts
+++ b/src/emergencyTriage/emergencyTriage.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class EmergencyTriageService {
+    getEmergencyTriageMessage(): string {
+        return 'Emergency Triage';
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from "@nestjs/core";
+import { EmergencyTriageModule } from "./emergencyTriage/emergencyTriage.module";
+
+async function App() {
+    const app = await NestFactory.create(EmergencyTriageModule);
+    app.listen(3000);
+
+}
+App();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,13 @@
 import { NestFactory } from "@nestjs/core";
-import { EmergencyTriageModule } from "./emergencyTriage/emergencyTriage.module";
+import { EmergencyTriageModule } from "./emergencyTriage.module";
+import { ConfigService } from "@nestjs/config";
 
 async function App() {
     const app = await NestFactory.create(EmergencyTriageModule);
-    app.listen(3000);
 
+    const configService = app.get(ConfigService);
+    const port = configService.get('PORT')
+
+    await app.listen(port);
 }
 App();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,10 @@
     "strict": true /* Enable all strict type-checking options. */,
 
     /* Completeness */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+
+    /* Source Maps */
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
   }
 }


### PR DESCRIPTION
Se ha añadido al repositorio las librerias necesarias para ejecutar nest.js y se ha creado inicialmente le modulo del emergencyTriage para el contexto de la HU #19 . Además en el capitulo de la Implementación se ha justificado la decisión de escoger esta herramineta 